### PR TITLE
Add filter expression support to JSONPath

### DIFF
--- a/.release-notes/add-jsonpath-filter-expressions.md
+++ b/.release-notes/add-jsonpath-filter-expressions.md
@@ -1,0 +1,38 @@
+## Add filter expression support to JSONPath
+
+JSONPath queries now support filter expressions (`?`) per RFC 9535 Section 2.3.5.1. Filters select array elements or object values that satisfy a logical condition.
+
+```pony
+let doc = JsonParser.parse(
+  """
+  {"books":[{"title":"A","price":8},{"title":"B","price":15}]}
+  """)?
+
+// Comparison: books under $10
+let cheap = JsonPathParser.compile("$.books[?@.price < 10]")?
+cheap.query(doc) // [{"title":"A","price":8}]
+
+// Existence: select elements where a key is present
+let has_title = JsonPathParser.compile("$.books[?@.title]")?
+has_title.query(doc) // both books
+
+// Logical operators: && (and), || (or), ! (not)
+let combined = JsonPathParser.compile(
+  "$.books[?@.price < 10 && @.title == 'A']")?
+
+// Absolute query ($) references the document root inside filters
+let by_default = JsonPathParser.compile(
+  "$.items[?@.type == $.default_type]")?
+```
+
+Supported filter features:
+
+* Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
+* Logical operators: `&&`, `||`, `!` with parenthesized grouping
+* Current node (`@`) and root (`$`) references
+* Literal values: strings, integers, floats, booleans, null
+* Existence tests (including non-singular queries like `@[*]`, `@..name`)
+* Nested filters
+* RFC 9535 semantics: missing keys produce "Nothing" (not null), no type coercion, mixed I64/F64 comparison converts to F64
+
+Function extensions (`length()`, `count()`, `match()`, etc.) are not yet supported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ make clean              # clean build artifacts + corral cache
 
 ## Project Status
 
-**Current state**: All features compile and run. Comprehensive test suite with 11 property-based tests (PonyCheck) and 26 example-based tests.
+**Current state**: All features compile and run. Comprehensive test suite with 12 property-based tests (PonyCheck) and 37 example-based tests.
 
 **What's implemented**:
 - Immutable JSON value types (`JsonObject`, `JsonArray`, `JsonNull`) backed by persistent collections (CHAMP Map, HAMT Vec)
@@ -24,7 +24,7 @@ make clean              # clean build artifacts + corral cache
 - Example program demonstrating all features
 
 **What's NOT implemented**:
-- JSONPath filter expressions `?()`, functions
+- JSONPath function extensions (`length()`, `count()`, `match()`, etc.)
 
 ## Architecture
 
@@ -73,14 +73,16 @@ With `JsonNull`, Pony's `None` serves its natural role: "no result yet" in `_Tre
 
 | File | Contents |
 |------|----------|
-| `_test.pony` | Test suite (11 property + 26 example tests) |
+| `_test.pony` | Test suite (12 property + 37 example tests) |
 | `_tree_builder.pony` | Assembles token events into `JsonType` tree |
 | `_json_print.pony` | Serialization (compact + pretty) |
 | `_traversal.pony` | Lens traversal trait and implementations |
 | `_json_path_parser.pony` | Recursive descent JSONPath parser |
-| `_json_path_selector.pony` | `_NameSelector`, `_IndexSelector`, `_WildcardSelector`, `_SliceSelector` |
+| `_json_path_selector.pony` | `_NameSelector`, `_IndexSelector`, `_WildcardSelector`, `_SliceSelector`, `_FilterSelector` |
 | `_json_path_segment.pony` | `_ChildSegment`, `_DescendantSegment` |
 | `_json_path_eval.pony` | JSONPath evaluation pipeline |
+| `_json_path_filter.pony` | Filter expression AST types |
+| `_json_path_filter_eval.pony` | Filter expression evaluator (`_FilterEval`, `_FilterCompare`) |
 
 ### Access Pattern Comparison
 

--- a/json/_json_path_eval.pony
+++ b/json/_json_path_eval.pony
@@ -2,24 +2,30 @@ primitive _JsonPathEval
   """
   Internal evaluator for compiled JSONPath queries.
 
-  Applies a sequence of segments to a root JSON value, producing an
+  Applies a sequence of segments to a starting JSON value, producing an
   array of matching values. Evaluation never raises — missing keys,
   wrong types, and out-of-bounds indices all produce empty results
   (per RFC 9535).
+
+  The `start` and `root` parameters are distinct: `start` is the node
+  the query begins from, while `root` is the original document root for
+  resolving absolute queries (`$`) inside filter expressions. For
+  top-level queries, both are the document root.
   """
 
   fun apply(
+    start: JsonType,
     root: JsonType,
     segments: Array[_Segment] val)
     : Array[JsonType] val
   =>
-    """Execute segments against root, returning matching values."""
+    """Execute segments against start, returning matching values."""
     recover val
       var current: Array[JsonType] ref = Array[JsonType]
-      current.push(root)
+      current.push(start)
 
       for segment in segments.values() do
-        current = _apply_segment(segment, current)
+        current = _apply_segment(segment, current, root)
       end
 
       current
@@ -27,30 +33,35 @@ primitive _JsonPathEval
 
   fun _apply_segment(
     segment: _Segment,
-    input: Array[JsonType] ref)
+    input: Array[JsonType] ref,
+    root: JsonType)
     : Array[JsonType] ref
   =>
     """Apply a segment to produce a new nodelist."""
     match segment
-    | let cs: _ChildSegment => _apply_child(cs.selectors(), input)
-    | let ds: _DescendantSegment => _apply_descendant(ds.selectors(), input)
+    | let cs: _ChildSegment =>
+      _apply_child(cs.selectors(), input, root)
+    | let ds: _DescendantSegment =>
+      _apply_descendant(ds.selectors(), input, root)
     end
 
   fun _apply_child(
     selectors: Array[_Selector] val,
-    input: Array[JsonType] ref)
+    input: Array[JsonType] ref,
+    root: JsonType)
     : Array[JsonType] ref
   =>
     """Apply selectors to each node in the input list."""
     let out = Array[JsonType]
     for node in input.values() do
-      _select_all(selectors, node, out)
+      _select_all(selectors, node, root, out)
     end
     out
 
   fun _apply_descendant(
     selectors: Array[_Selector] val,
-    input: Array[JsonType] ref)
+    input: Array[JsonType] ref,
+    root: JsonType)
     : Array[JsonType] ref
   =>
     """
@@ -59,27 +70,32 @@ primitive _JsonPathEval
     """
     let out = Array[JsonType]
     for node in input.values() do
-      _descend(selectors, node, out)
+      _descend(selectors, node, root, out)
     end
     out
 
   fun _descend(
     selectors: Array[_Selector] val,
     node: JsonType,
+    root: JsonType,
     out: Array[JsonType] ref)
   =>
     """Depth-first pre-order: apply selectors here, then recurse."""
-    _select_all(selectors, node, out)
+    _select_all(selectors, node, root, out)
     match node
     | let obj: JsonObject =>
-      for v in obj.values() do _descend(selectors, v, out) end
+      for v in obj.values() do _descend(selectors, v, root, out) end
     | let arr: JsonArray =>
-      for v in arr.values() do _descend(selectors, v, out) end
+      for v in arr.values() do _descend(selectors, v, root, out) end
     end
 
+  // _FilterSelector.select takes an extra `root` parameter. This is
+  // handled here via explicit match dispatch — changing the _FilterSelector
+  // match arm without affecting other selectors' signatures.
   fun _select_all(
     selectors: Array[_Selector] val,
     node: JsonType,
+    root: JsonType,
     out: Array[JsonType] ref)
   =>
     """Apply all selectors to a single node."""
@@ -89,5 +105,6 @@ primitive _JsonPathEval
       | let s: _IndexSelector => s.select(node, out)
       | _WildcardSelector => _WildcardSelector.select(node, out)
       | let s: _SliceSelector => s.select(node, out)
+      | let s: _FilterSelector => s.select(node, root, out)
       end
     end

--- a/json/_json_path_filter.pony
+++ b/json/_json_path_filter.pony
@@ -1,0 +1,160 @@
+// Filter expression AST types for JSONPath (RFC 9535 Section 2.3.5).
+//
+// These types represent the parsed filter expression tree stored inside
+// _FilterSelector. All types are val — constructed at parse time and
+// evaluated immutably against JSON documents.
+
+primitive _Nothing
+  """
+  Represents the absence of a value from a singular query result.
+
+  Distinct from `JsonNull` (JSON null) per RFC 9535: a missing key yields
+  `_Nothing`, while a key mapped to `null` yields `JsonNull`. Two Nothings
+  compare equal; Nothing compared to any value is false (except `!=`).
+  """
+
+// The result of evaluating a singular query: either a value or absence.
+type _QueryResult is (JsonType | _Nothing)
+
+// --- Comparison operators ---
+
+primitive _CmpEq
+primitive _CmpNeq
+primitive _CmpLt
+primitive _CmpLte
+primitive _CmpGt
+primitive _CmpGte
+
+type _ComparisonOp is
+  (_CmpEq | _CmpNeq | _CmpLt | _CmpLte | _CmpGt | _CmpGte)
+
+// --- Singular segments (name/index only, no wildcards/slices/descendants) ---
+
+class val _SingularNameSegment
+  """Select an object member by key in a singular query."""
+  let name: String
+
+  new val create(name': String) =>
+    name = name'
+
+class val _SingularIndexSegment
+  """Select an array element by index in a singular query."""
+  let index: I64
+
+  new val create(index': I64) =>
+    index = index'
+
+type _SingularSegment is (_SingularNameSegment | _SingularIndexSegment)
+
+// --- Singular queries (used in comparisons) ---
+
+class val _RelSingularQuery
+  """Singular query relative to the current node (@)."""
+  let segments: Array[_SingularSegment] val
+
+  new val create(segments': Array[_SingularSegment] val) =>
+    segments = segments'
+
+class val _AbsSingularQuery
+  """Singular query relative to the document root ($)."""
+  let segments: Array[_SingularSegment] val
+
+  new val create(segments': Array[_SingularSegment] val) =>
+    segments = segments'
+
+type _SingularQuery is (_RelSingularQuery | _AbsSingularQuery)
+
+// --- Comparables (what can appear on either side of a comparison) ---
+// Expands to: String | I64 | F64 | Bool | JsonNull |
+//             _RelSingularQuery | _AbsSingularQuery
+
+type _LiteralValue is (String | I64 | F64 | Bool | JsonNull)
+
+type _Comparable is (_LiteralValue | _SingularQuery)
+
+// --- Filter queries (used in existence tests, can be non-singular) ---
+
+class val _RelFilterQuery
+  """General query relative to the current node (@)."""
+  let segments: Array[_Segment] val
+
+  new val create(segments': Array[_Segment] val) =>
+    segments = segments'
+
+class val _AbsFilterQuery
+  """General query relative to the document root ($)."""
+  let segments: Array[_Segment] val
+
+  new val create(segments': Array[_Segment] val) =>
+    segments = segments'
+
+type _FilterQuery is (_RelFilterQuery | _AbsFilterQuery)
+
+// --- Logical expression AST ---
+
+class val _OrExpr
+  """Logical OR: true if either operand is true."""
+  let left: _LogicalExpr
+  let right: _LogicalExpr
+
+  new val create(left': _LogicalExpr, right': _LogicalExpr) =>
+    left = left'
+    right = right'
+
+class val _AndExpr
+  """Logical AND: true if both operands are true."""
+  let left: _LogicalExpr
+  let right: _LogicalExpr
+
+  new val create(left': _LogicalExpr, right': _LogicalExpr) =>
+    left = left'
+    right = right'
+
+class val _NotExpr
+  """Logical NOT: inverts the operand."""
+  let expr: _LogicalExpr
+
+  new val create(expr': _LogicalExpr) =>
+    expr = expr'
+
+class val _ComparisonExpr
+  """
+  Comparison between two comparables.
+
+  Both sides are either literal values or singular queries (which produce
+  at most one node). Non-singular queries are not allowed in comparisons
+  per RFC 9535 — that constraint is enforced at the type level by using
+  `_Comparable` rather than `_FilterQuery`.
+  """
+  let left: _Comparable
+  let op: _ComparisonOp
+  let right: _Comparable
+
+  new val create(
+    left': _Comparable,
+    op': _ComparisonOp,
+    right': _Comparable)
+  =>
+    left = left'
+    op = op'
+    right = right'
+
+class val _ExistenceExpr
+  """
+  Existence test: true if the filter query selects at least one node.
+
+  Unlike comparisons, existence tests can use non-singular queries
+  (wildcards, slices, descendants).
+  """
+  let query: _FilterQuery
+
+  new val create(query': _FilterQuery) =>
+    query = query'
+
+type _LogicalExpr is
+  ( _OrExpr
+  | _AndExpr
+  | _NotExpr
+  | _ComparisonExpr
+  | _ExistenceExpr
+  )

--- a/json/_json_path_filter_eval.pony
+++ b/json/_json_path_filter_eval.pony
@@ -1,0 +1,240 @@
+primitive _FilterEval
+  """
+  Evaluate a filter expression against a current node and document root.
+
+  Returns `true` if the expression matches, `false` otherwise. Evaluation
+  never raises — type mismatches, missing keys, and out-of-bounds indices
+  all produce well-defined results per RFC 9535.
+  """
+
+  fun apply(
+    expr: _LogicalExpr,
+    current: JsonType,
+    root: JsonType)
+    : Bool
+  =>
+    match expr
+    | let e: _OrExpr =>
+      apply(e.left, current, root) or apply(e.right, current, root)
+    | let e: _AndExpr =>
+      apply(e.left, current, root) and apply(e.right, current, root)
+    | let e: _NotExpr =>
+      not apply(e.expr, current, root)
+    | let e: _ComparisonExpr =>
+      _FilterCompare(e.left, e.op, e.right, current, root)
+    | let e: _ExistenceExpr =>
+      _eval_existence(e.query, current, root)
+    end
+
+  fun _eval_existence(
+    query: _FilterQuery,
+    current: JsonType,
+    root: JsonType)
+    : Bool
+  =>
+    """True if the query selects at least one node."""
+    let results = match query
+    | let q: _RelFilterQuery =>
+      _JsonPathEval(current, root, q.segments)
+    | let q: _AbsFilterQuery =>
+      _JsonPathEval(root, root, q.segments)
+    end
+    results.size() > 0
+
+  fun _eval_singular(
+    query: _SingularQuery,
+    current: JsonType,
+    root: JsonType)
+    : _QueryResult
+  =>
+    """
+    Evaluate a singular query, returning the single value or `_Nothing`
+    if no value exists at that path.
+    """
+    var node: _QueryResult = match query
+    | let q: _RelSingularQuery => current
+    | let q: _AbsSingularQuery => root
+    end
+    let segs = match query
+    | let q: _RelSingularQuery => q.segments
+    | let q: _AbsSingularQuery => q.segments
+    end
+    for seg in segs.values() do
+      match node
+      | let j: JsonType =>
+        node = match seg
+        | let ns: _SingularNameSegment =>
+          match j
+          | let obj: JsonObject =>
+            try obj(ns.name)? else _Nothing end
+          else
+            _Nothing
+          end
+        | let is': _SingularIndexSegment =>
+          match j
+          | let arr: JsonArray =>
+            let idx = is'.index
+            let effective = if idx >= 0 then
+              idx.usize()
+            else
+              let abs_idx = idx.abs().usize()
+              if abs_idx <= arr.size() then
+                arr.size() - abs_idx
+              else
+                return _Nothing
+              end
+            end
+            try arr(effective)? else _Nothing end
+          else
+            _Nothing
+          end
+        end
+      | _Nothing => return _Nothing
+      end
+    end
+    node
+
+
+primitive _FilterCompare
+  """
+  RFC 9535 comparison semantics for filter expressions.
+
+  Handles Nothing (absent query result), type-specific equality and
+  ordering, deep equality for arrays/objects, mixed I64/F64 comparison,
+  and cross-type comparisons (always false, no coercion).
+  """
+
+  fun apply(
+    left: _Comparable,
+    op: _ComparisonOp,
+    right: _Comparable,
+    current: JsonType,
+    root: JsonType)
+    : Bool
+  =>
+    let lval = _resolve(left, current, root)
+    let rval = _resolve(right, current, root)
+    match op
+    | _CmpEq  => _eq(lval, rval)
+    | _CmpNeq => not _eq(lval, rval)
+    | _CmpLt  => _lt(lval, rval)
+    | _CmpLte => _lt(lval, rval) or _eq(lval, rval)
+    | _CmpGt  => _lt(rval, lval)
+    | _CmpGte => _lt(rval, lval) or _eq(lval, rval)
+    end
+
+  fun _resolve(
+    c: _Comparable,
+    current: JsonType,
+    root: JsonType)
+    : _QueryResult
+  =>
+    """Resolve a comparable to a concrete value or Nothing."""
+    match c
+    | let s: String => s
+    | let n: I64 => n
+    | let n: F64 => n
+    | let b: Bool => b
+    | JsonNull => JsonNull
+    | let q: _RelSingularQuery =>
+      _FilterEval._eval_singular(q, current, root)
+    | let q: _AbsSingularQuery =>
+      _FilterEval._eval_singular(q, current, root)
+    end
+
+  fun _eq(left: _QueryResult, right: _QueryResult): Bool =>
+    """
+    RFC 9535 equality.
+
+    Nothing == Nothing is true. Nothing vs any value is false.
+    Same-type primitives use value equality. Mixed I64/F64 converts
+    I64 to F64. Arrays compare element-wise recursively. Objects
+    compare by same key set with recursively equal values (iteration
+    order doesn't matter). Cross-type is false.
+    """
+    match (left, right)
+    | (_Nothing, _Nothing) => true
+    | (_Nothing, _) => false
+    | (_, _Nothing) => false
+    | (let a: I64, let b: I64) => a == b
+    | (let a: F64, let b: F64) => a == b
+    | (let a: I64, let b: F64) => a.f64() == b
+    | (let a: F64, let b: I64) => a == b.f64()
+    | (let a: String, let b: String) => a == b
+    | (let a: Bool, let b: Bool) => a == b
+    | (JsonNull, JsonNull) => true
+    | (let a: JsonArray, let b: JsonArray) => _array_eq(a, b)
+    | (let a: JsonObject, let b: JsonObject) => _object_eq(a, b)
+    else
+      false
+    end
+
+  fun _lt(left: _QueryResult, right: _QueryResult): Bool =>
+    """
+    RFC 9535 ordering.
+
+    Anything involving Nothing is false. Numbers (including mixed
+    I64/F64) use mathematical ordering. Strings use Unicode scalar
+    value lexicographic ordering. All other types and cross-type
+    comparisons are false.
+    """
+    match (left, right)
+    | (_Nothing, _) => false
+    | (_, _Nothing) => false
+    | (let a: I64, let b: I64) => a < b
+    | (let a: F64, let b: F64) => a < b
+    | (let a: I64, let b: F64) => a.f64() < b
+    | (let a: F64, let b: I64) => a < b.f64()
+    | (let a: String, let b: String) => a < b
+    else
+      false
+    end
+
+  fun _array_eq(a: JsonArray, b: JsonArray): Bool =>
+    """Element-wise recursive equality for arrays."""
+    if a.size() != b.size() then return false end
+    var i: USize = 0
+    while i < a.size() do
+      try
+        if not _deep_eq(a(i)?, b(i)?) then return false end
+      else
+        return false
+      end
+      i = i + 1
+    end
+    true
+
+  fun _object_eq(a: JsonObject, b: JsonObject): Bool =>
+    """
+    Key/value recursive equality for objects.
+
+    Checks that both objects have the same number of keys, then verifies
+    every key in `a` exists in `b` with a recursively equal value.
+    Iteration order doesn't matter (JsonObject is backed by CHAMP map).
+    """
+    if a.size() != b.size() then return false end
+    for (key, a_val) in a.pairs() do
+      try
+        let b_val = b(key)?
+        if not _deep_eq(a_val, b_val) then return false end
+      else
+        return false
+      end
+    end
+    true
+
+  fun _deep_eq(a: JsonType, b: JsonType): Bool =>
+    """Recursive equality for JsonType values."""
+    match (a, b)
+    | (let x: I64, let y: I64) => x == y
+    | (let x: F64, let y: F64) => x == y
+    | (let x: I64, let y: F64) => x.f64() == y
+    | (let x: F64, let y: I64) => x == y.f64()
+    | (let x: String, let y: String) => x == y
+    | (let x: Bool, let y: Bool) => x == y
+    | (JsonNull, JsonNull) => true
+    | (let x: JsonArray, let y: JsonArray) => _array_eq(x, y)
+    | (let x: JsonObject, let y: JsonObject) => _object_eq(x, y)
+    else
+      false
+    end

--- a/json/_json_path_parser.pony
+++ b/json/_json_path_parser.pony
@@ -99,10 +99,12 @@ class ref _JsonPathParser
   fun ref _parse_selector(): _Selector ? =>
     """
     Parse a single selector inside brackets.
-    Distinguishes: string name, wildcard, index, or slice.
+    Distinguishes: filter, string name, wildcard, index, or slice.
     """
     _skip_whitespace()
-    if _looking_at('*') then
+    if _looking_at('?') then
+      _parse_filter_selector()?
+    elseif _looking_at('*') then
       _advance(1)
       _WildcardSelector
     elseif _looking_at('\'') or _looking_at('"') then
@@ -288,6 +290,315 @@ class ref _JsonPathParser
       _source.substring(start.isize(), _offset.isize())
     let abs_val = num_str.i64()?
     if negative then -abs_val else abs_val end
+
+  // --- Filter expression parsing ---
+
+  fun ref _parse_filter_selector(): _FilterSelector ? =>
+    """Parse a filter selector: '?' logical-expr."""
+    _advance(1) // consume '?'
+    _skip_whitespace()
+    let expr = _parse_logical_or_expr()?
+    _FilterSelector(expr)
+
+  fun ref _parse_logical_or_expr(): _LogicalExpr ? =>
+    """Parse logical-or: logical-and *('||' logical-and)."""
+    var left = _parse_logical_and_expr()?
+    while true do
+      _skip_whitespace()
+      if _looking_at_str("||") then
+        _advance(2)
+        _skip_whitespace()
+        let right = _parse_logical_and_expr()?
+        left = _OrExpr(left, right)
+      else
+        break
+      end
+    end
+    left
+
+  fun ref _parse_logical_and_expr(): _LogicalExpr ? =>
+    """Parse logical-and: basic-expr *('&&' basic-expr)."""
+    var left = _parse_basic_expr()?
+    while true do
+      _skip_whitespace()
+      if _looking_at_str("&&") then
+        _advance(2)
+        _skip_whitespace()
+        let right = _parse_basic_expr()?
+        left = _AndExpr(left, right)
+      else
+        break
+      end
+    end
+    left
+
+  fun ref _parse_basic_expr(): _LogicalExpr ? =>
+    """
+    Parse a basic expression: negation, parenthesized, query-based
+    (test or comparison), or literal-first comparison.
+    """
+    _skip_whitespace()
+    if _looking_at('!') then
+      _advance(1)
+      _skip_whitespace()
+      if _looking_at('(') then
+        // Negated parenthesized expression
+        _NotExpr(_parse_paren_expr()?)
+      elseif _looking_at('@') or _looking_at('$') then
+        // Negated existence test
+        let is_rel = _looking_at('@')
+        _advance(1)
+        let segments = _parse_filter_segments()?
+        let query: _FilterQuery = if is_rel then
+          _RelFilterQuery(segments)
+        else
+          _AbsFilterQuery(segments)
+        end
+        _NotExpr(_ExistenceExpr(query))
+      else
+        _fail("Expected '(', '@', or '$' after '!'")
+        error
+      end
+    elseif _looking_at('(') then
+      _parse_paren_expr()?
+    elseif _looking_at('@') or _looking_at('$') then
+      _parse_test_or_comparison()?
+    else
+      // Must be a literal-first comparison: literal op comparable
+      let left: _Comparable = _parse_literal()?
+      _skip_whitespace()
+      let op = _parse_comparison_op()?
+      _skip_whitespace()
+      let right = _parse_comparable()?
+      _ComparisonExpr(left, op, right)
+    end
+
+  fun ref _parse_paren_expr(): _LogicalExpr ? =>
+    """Parse '(' logical-expr ')'."""
+    _eat('(')?
+    _skip_whitespace()
+    let expr = _parse_logical_or_expr()?
+    _skip_whitespace()
+    _eat(')')?
+    expr
+
+  fun ref _parse_test_or_comparison(): _LogicalExpr ? =>
+    """
+    Disambiguate test-expr vs comparison-expr starting with @ or $.
+
+    Strategy: save position, try parsing singular segments (name/index
+    only). If a comparison operator follows, it's a comparison. Otherwise,
+    reset and re-parse as general filter segments for an existence test.
+    """
+    let is_rel = _looking_at('@')
+    _advance(1) // consume @ or $
+    let segments_start = _offset
+
+    // Try parsing as singular query + comparison op
+    try
+      let singular_segs = _parse_singular_segments()?
+      _skip_whitespace()
+      if _looking_at_comparison_op() then
+        // It's a comparison
+        let query: _SingularQuery = if is_rel then
+          _RelSingularQuery(singular_segs)
+        else
+          _AbsSingularQuery(singular_segs)
+        end
+        let left: _Comparable = query
+        let op = _parse_comparison_op()?
+        _skip_whitespace()
+        let right = _parse_comparable()?
+        return _ComparisonExpr(left, op, right)
+      end
+    end
+
+    // Not a comparison — re-parse as general filter query for existence test
+    _offset = segments_start
+    let segments = _parse_filter_segments()?
+    let query: _FilterQuery = if is_rel then
+      _RelFilterQuery(segments)
+    else
+      _AbsFilterQuery(segments)
+    end
+    _ExistenceExpr(query)
+
+  fun ref _parse_comparable(): _Comparable ? =>
+    """Parse a comparable: singular query or literal."""
+    _skip_whitespace()
+    if _looking_at('@') then
+      _advance(1)
+      let segs = _parse_singular_segments()?
+      _RelSingularQuery(segs)
+    elseif _looking_at('$') then
+      _advance(1)
+      let segs = _parse_singular_segments()?
+      _AbsSingularQuery(segs)
+    else
+      _parse_literal()?
+    end
+
+  fun ref _parse_literal(): _LiteralValue ? =>
+    """Parse a literal value: string, number, true, false, or null."""
+    _skip_whitespace()
+    if _looking_at('\'') or _looking_at('"') then
+      _parse_quoted_string()?
+    elseif _looking_at_str("true") then
+      _advance(4)
+      true
+    elseif _looking_at_str("false") then
+      _advance(5)
+      false
+    elseif _looking_at_str("null") then
+      _advance(4)
+      JsonNull
+    else
+      _parse_json_number()?
+    end
+
+  fun ref _parse_json_number(): _LiteralValue ? =>
+    """Parse a full JSON number: ['-'] int ['.' digits] [('e'|'E') [sign] digits]."""
+    let start = _offset
+    var is_float = false
+
+    // Optional negative sign
+    if _looking_at('-') then _advance(1) end
+
+    // Integer part
+    if _looking_at('0') then
+      _advance(1)
+    else
+      if _offset >= _source.size() then
+        _fail("Expected digit")
+        error
+      end
+      let c = _source(_offset)?
+      if not _is_digit(c) then
+        _fail("Expected digit")
+        error
+      end
+      _advance(1)
+      while (_offset < _source.size()) and
+        try _is_digit(_source(_offset)?) else false end
+      do
+        _advance(1)
+      end
+    end
+
+    // Optional fraction
+    if _looking_at('.') then
+      is_float = true
+      _advance(1)
+      let frac_start = _offset
+      while (_offset < _source.size()) and
+        try _is_digit(_source(_offset)?) else false end
+      do
+        _advance(1)
+      end
+      if _offset == frac_start then
+        _fail("Expected digit after decimal point")
+        error
+      end
+    end
+
+    // Optional exponent
+    if try
+      let c = _source(_offset)?
+      (c == 'e') or (c == 'E')
+    else false end then
+      is_float = true
+      _advance(1)
+      if _looking_at('+') or _looking_at('-') then _advance(1) end
+      let exp_start = _offset
+      while (_offset < _source.size()) and
+        try _is_digit(_source(_offset)?) else false end
+      do
+        _advance(1)
+      end
+      if _offset == exp_start then
+        _fail("Expected digit in exponent")
+        error
+      end
+    end
+
+    let num_str: String val =
+      _source.substring(start.isize(), _offset.isize())
+    if is_float then
+      let v: _LiteralValue = num_str.f64()?
+      v
+    else
+      let v: _LiteralValue = num_str.i64()?
+      v
+    end
+
+  fun ref _parse_singular_segments(): Array[_SingularSegment] val ? =>
+    """
+    Parse segments restricted to name and index only (no wildcards,
+    slices, descendants, or filters). Raises on non-singular syntax.
+    """
+    let segs = recover iso Array[_SingularSegment] end
+    while _offset < _source.size() do
+      if _looking_at('.') and (not _looking_at_str("..")) then
+        _advance(1)
+        let name = _parse_member_name()?
+        segs.push(_SingularNameSegment(name))
+      elseif _looking_at('[') then
+        _advance(1)
+        _skip_whitespace()
+        if _looking_at('\'') or _looking_at('"') then
+          let name = _parse_quoted_string()?
+          _skip_whitespace()
+          _eat(']')?
+          segs.push(_SingularNameSegment(name))
+        else
+          let idx = _parse_int()?
+          _skip_whitespace()
+          // Must be ] — if it's : then it's a slice (not singular)
+          _eat(']')?
+          segs.push(_SingularIndexSegment(idx))
+        end
+      else
+        break
+      end
+    end
+    consume segs
+
+  fun ref _parse_filter_segments(): Array[_Segment] val ? =>
+    """
+    Parse general segments for filter queries (existence tests).
+
+    Stops when the next character is not '.' or '['. Bracket selectors
+    within the query (e.g., `@.items[0]`) are consumed in full by the
+    existing `_parse_bracket_selectors`, so nested ']' does not
+    prematurely terminate parsing.
+    """
+    let segments = recover iso Array[_Segment] end
+    while _offset < _source.size() do
+      _skip_whitespace()
+      if not (_looking_at('.') or _looking_at('[')) then break end
+      segments.push(_parse_segment()?)
+    end
+    consume segments
+
+  fun ref _parse_comparison_op(): _ComparisonOp ? =>
+    """Parse a comparison operator: ==, !=, <=, >=, <, >."""
+    // Check two-char operators before single-char
+    if _looking_at_str("==") then _advance(2); _CmpEq
+    elseif _looking_at_str("!=") then _advance(2); _CmpNeq
+    elseif _looking_at_str("<=") then _advance(2); _CmpLte
+    elseif _looking_at_str(">=") then _advance(2); _CmpGte
+    elseif _looking_at('<') then _advance(1); _CmpLt
+    elseif _looking_at('>') then _advance(1); _CmpGt
+    else
+      _fail("Expected comparison operator")
+      error
+    end
+
+  fun _looking_at_comparison_op(): Bool =>
+    """Check if the current position starts with a comparison operator."""
+    _looking_at_str("==") or _looking_at_str("!=") or
+    _looking_at_str("<=") or _looking_at_str(">=") or
+    _looking_at('<') or _looking_at('>')
 
   // --- Character primitives ---
 

--- a/json/json.pony
+++ b/json/json.pony
@@ -153,6 +153,10 @@ Supported JSONPath syntax:
 * `$[0:3]` — slice (start inclusive, end exclusive)
 * `$[::2]` or `$[::-1]` — slice with step (forward or reverse)
 * `$[0,2,4]` — union (multiple indices or names)
+* `$[?@.price < 10]` — filter by comparison
+* `$[?@.author]` — filter by existence (member present)
+* `$[?@.a > 1 && @.b < 2]` — logical AND, OR (`||`), NOT (`!`)
+* `$[?@.type == $.default]` — absolute query (`$`) in filters
 * `query_one()` — convenience returning first match or `NotFound`
 
 ## Serialization
@@ -233,8 +237,8 @@ For most use cases, `JsonParser.parse()` is simpler and sufficient.
 
 ## Limitations
 
-JSONPath filter expressions (`?(...)`) and function extensions are not
-supported.
+JSONPath function extensions (`length()`, `count()`, `match()`, etc.) are
+not supported.
 """
 
 use "collections/persistent"

--- a/json/json_path.pony
+++ b/json/json_path.pony
@@ -35,7 +35,7 @@ class val JsonPath
     Returns all matching values. Returns an empty array if no values
     match. Evaluation never errors.
     """
-    _JsonPathEval(root, _segments)
+    _JsonPathEval(root, root, _segments)
 
   fun query_one(root: JsonType): (JsonType | NotFound) =>
     """


### PR DESCRIPTION
Implement RFC 9535 Section 2.3.5.1 filter expressions for JSONPath queries. Filters select array elements or object values that satisfy a logical condition.

Three layers added:

- **AST types** (`_json_path_filter.pony`): Union type hierarchy modeling the RFC grammar. Singular queries are a distinct type from general filter queries, enforcing at the type level that comparisons require singular queries while existence tests allow any query.
- **Evaluator** (`_json_path_filter_eval.pony`): RFC 9535 comparison semantics — Nothing (absent key) is distinct from null, no type coercion, mixed I64/F64 converts to F64, deep equality for arrays/objects.
- **Parser extension** (`_json_path_parser.pony`): Precedence-climbing expression parsing with backtracking to disambiguate existence tests from comparisons.

The evaluation pipeline gains a `start`/`root` parameter distinction so `$` references inside filters resolve against the document root, not the current filtered element.

Supported: `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`, `@`/`$` references, literals, existence tests, parenthesized grouping, nested filters. Function extensions are out of scope (#5).

Closes #4